### PR TITLE
Support Programmatic Creation/Deletion of Custom Fields

### DIFF
--- a/samples/test-custom-field-create-delete.py
+++ b/samples/test-custom-field-create-delete.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import time
+from thehive4py.api import TheHiveApi
+from thehive4py.models import CustomFieldHelper
+
+api = TheHiveApi('http://10.0.0.30:9000', 'oW60FLDIOzaAUnOh5+RX7x3dfYallLpA')
+
+string_custom_field = CustomFieldHelper.create_new_field(
+    'string',
+    'Test String Custom Field',
+    value=['First Option', 'Second Option', 'Third Option'],
+    reference='testStringField',
+    description='This is the description for the test string custom field')
+
+print("Creating a string custom field")
+creation_result = api.create_custom_field(string_custom_field)
+
+if creation_result:
+    print("ID: {}".format(creation_result))
+    print("Sleeping for 30 seconds. Go check your custom fields for {}".format(string_custom_field['reference']))
+    time.sleep(30)
+else:
+    print("could not create string custom field")
+    exit()
+
+print("Removing a string custom field")
+deletion_result = api.delete_custom_field(creation_result)
+
+if deletion_result:
+    print("Deleted string custom field with ID {}".format(creation_result))
+else:
+    print("Could not delete string custom field with ID {}".format(creation_result))
+
+
+boolean_custom_field = CustomFieldHelper.create_new_field(
+        "boolean",
+        "Was it bad?",
+        reference="badPreference",
+        description="Tell me if it was bad or not")
+
+print("")
+print("Creating a boolean custom field")
+creation_result = api.create_custom_field(boolean_custom_field)
+
+if creation_result:
+    print("ID: {}".format(creation_result))
+    print("Sleeping for 30 seconds. Go check your custom fields for {}".format(boolean_custom_field['reference']))
+    time.sleep(30)
+else:
+    print("could not create boolean custom field")
+    exit()
+
+print("Removing a boolean custom field")
+deletion_result = api.delete_custom_field(creation_result)
+
+if deletion_result:
+    print("Deleted boolean custom field with ID {}".format(creation_result))
+else:
+    print("Could not delete boolean custom field with ID {}".format(creation_result))

--- a/thehive4py/exceptions.py
+++ b/thehive4py/exceptions.py
@@ -17,3 +17,6 @@ class AlertException(TheHiveException):
 
 class CaseTemplateException(TheHiveException):
     pass
+
+class CustomFieldException(TheHiveException):
+    pass

--- a/thehive4py/models.py
+++ b/thehive4py/models.py
@@ -38,6 +38,16 @@ class CustomFieldHelper(object):
     def __init__(self):
         self.fields = {}
 
+    @staticmethod
+    def create_new_field(field_type, name, value=[], reference='', description=''):
+        custom_field = dict()
+        custom_field['name'] = name
+        custom_field['type'] = field_type
+        custom_field['options'] = value
+        custom_field['reference'] = reference
+        custom_field['description'] = description
+        return custom_field
+
     def __add_field(self, type, name, value):
         custom_field = dict()
         custom_field['order'] = len(self.fields)


### PR DESCRIPTION
The new CustomFieldHelper is useful for adding a custom field(s) to a case or case template, but cannot be used to create a new custom field in TheHive. There are several fields missing such as reference, options, and description - all of which are required fields in TheHive GUI. This PR provides the ability programmatically create (or delete) Custom Fields. This feature is useful for deploying TheHive in multiple environments and wanting to utilize a standardized naming convention.

This PR adds the following support:
* Implements new exception `CustomFieldException`
* Adds `create_custom_field` and `delete_custom_field` methods to TheHive4py API
* Adds a static method named `create_new_field` to CustomFieldHelper - returns a dict that can be passed to create_custom_field.
* Added example file `test-custom-field-create-delete` to demonstrate adding and deleting custom fields using the methods above.

This PR is an updated version of PR #52 (now closed).