### PR TITLE
Prevent max recursion depth exceeded error

### DIFF
--- a/thehive4py/models.py
+++ b/thehive4py/models.py
@@ -18,7 +18,7 @@ class CustomJsonEncoder(json.JSONEncoder):
         if isinstance(o, JSONSerializable):
             return o.__dict__
         else:
-            return json.JSONEncoder.encode(self, o)
+            return json.JSONEncoder.default(self, o)
 
 
 class JSONSerializable(object):


### PR DESCRIPTION
If we fail to return a serializable type fallback to standard default method to raise exception, rather then recursing forever causing max recursion depth exceeded error.