### PR TITLE
Specify an optional case template parameter to promote_alert_to_case

### DIFF
--- a/thehive4py/api.py
+++ b/thehive4py/api.py
@@ -448,11 +448,12 @@ class TheHiveApi:
 
         return self.__find_rows("/api/alert/_search", **attributes)
 
-    def promote_alert_to_case(self, alert_id):
+    def promote_alert_to_case(self, alert_id, case_template = None):
         """
             This uses the TheHiveAPI to promote an alert to a case
 
             :param alert_id: Alert identifier
+            :param case_template: Optional Case Template name
             :return: TheHive Case
             :rtype: json
         """
@@ -462,7 +463,7 @@ class TheHiveApi:
         try:
             return requests.post(req, headers={'Content-Type': 'application/json'},
                                  proxies=self.proxies, auth=self.auth,
-                                 verify=self.cert, data=json.dumps({}))
+                                 verify=self.cert, data=json.dumps({"caseTemplate": case_template}))
 
         except requests.exceptions.RequestException as the_exception:
             raise AlertException("Couldn't promote alert to case: {}".format(the_exception))


### PR DESCRIPTION
As a workaround for this issues

https://github.com/TheHive-Project/TheHive4py/issues/114

https://github.com/TheHive-Project/TheHive/issues/929

You can firstly get the alert `caseTemplate` before promoting it.