### PR TITLE
Add id for case template

### DIFF
--- a/thehive4py/models.py
+++ b/thehive4py/models.py
@@ -229,6 +229,7 @@ class CaseTemplate(JSONSerializable):
             attributes = attributes['json']
 
         self.name = attributes.get('name', None)
+        self.id = attributes.get('id', None)
         self.titlePrefix = attributes.get('titlePrefix', None)
         self.description = attributes.get('description', None)
         self.severity = attributes.get('severity', 2)


### PR DESCRIPTION
Add one line to extract case template ID from json response.
ID is needed to further actions with case templates like update or delete.