### PR TITLE
Added Ability to Update Case Information when Promoting Alert

### DIFF
--- a/thehive4py/api.py
+++ b/thehive4py/api.py
@@ -448,7 +448,7 @@ class TheHiveApi:
 
         return self.__find_rows("/api/alert/_search", **attributes)
 
-    def promote_alert_to_case(self, alert_id):
+    def promote_alert_to_case(self, alert_id, data={}):
         """
             This uses the TheHiveAPI to promote an alert to a case
 
@@ -462,7 +462,7 @@ class TheHiveApi:
         try:
             return requests.post(req, headers={'Content-Type': 'application/json'},
                                  proxies=self.proxies, auth=self.auth,
-                                 verify=self.cert, data=json.dumps({}))
+                                 verify=self.cert, data=json.dumps(data))
 
         except requests.exceptions.RequestException as the_exception:
             raise AlertException("Couldn't promote alert to case: {}".format(the_exception))


### PR DESCRIPTION
Added code changes to optionally send data to add additional information to the case when promoting an alert.

for example:
alert_id = "123"
caseTemplate = "TheDefaultTemplate"
thehive4py.api.promote_alert_to_case(alert_id, {"caseTemplate": caseTemplate})