### PR TITLE
Fix documentation mismatch on api.find_first TheHive-Project/TheHive4py#165

### DIFF
--- a/thehive4py/api.py
+++ b/thehive4py/api.py
@@ -428,7 +428,6 @@ class TheHiveApi:
             query (dict): A query object, defined in JSON format or using utiliy methods from thehive4py.query module
             sort (Array): List of fields to sort the result with. Prefix the field name with `-` for descending order
                 and `+` for ascending order
-            range (str): A range describing the number of rows to be returned
 
         Returns:
             response (requests.Response): Response object including a JSON description of the case.
@@ -436,6 +435,7 @@ class TheHiveApi:
         Raises:
             CaseException: An error occured during case search
         """
+        attributes['range'] = '0-1'
         return self.find_cases(**attributes).json()[0]
 
     def get_case_observables(self, case_id, **attributes):

--- a/thehive4py/api.py
+++ b/thehive4py/api.py
@@ -436,7 +436,7 @@ class TheHiveApi:
             CaseException: An error occured during case search
         """
         attributes['range'] = '0-1'
-        return self.find_cases(**attributes).json()[0]
+        return self.find_cases(**attributes)
 
     def get_case_observables(self, case_id, **attributes):
 


### PR DESCRIPTION
Fixes: TheHive-Project/TheHive4py#165

1. This PR changes the `api.find_first` function to return a `requests.Response` object instead of a Python dict as it should be according to the docstrings.
2. Additionally, the previous behaviour was to still query for either all cases matching the query or a user specified range and then return only the first element from the `requests.Response` object.
This PR changes the logic by overwriting the `range` parameter to `0-1` which means we actually ask The Hive to only provide one case.
3. Removed the `range` parameter from the docstrings Arguments list, since we now set it statically.

