### PR TITLE
Allow params and query in get_task_logs()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ build.sh
 doc-deploy.sh
 .DS_Store
 site/
+notebook

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,18 @@
 # Change Log
 
-## [1.7.1](https://github.com/TheHive-Project/TheHive4py/tree/1.7.1) (2020-06-04)
+## [1.7.2](https://github.com/TheHive-Project/TheHive4py/tree/1.7.2) (2020-06-24)
+[Full Changelog](https://github.com/TheHive-Project/TheHive4py/compare/1.7.1...1.7.2)
 
+**Fixed bugs:**
+
+- Fix the constructor of TheHiveApi class [\#170](https://github.com/TheHive-Project/TheHive4py/issues/170)
+- NameError: name 'requests' is not defined [\#163](https://github.com/TheHive-Project/TheHive4py/issues/163)
+
+**Merged pull requests:**
+
+- Importing requests module [\#168](https://github.com/TheHive-Project/TheHive4py/pull/168) ([gaglimax](https://github.com/gaglimax))
+
+## [1.7.1](https://github.com/TheHive-Project/TheHive4py/tree/1.7.1) (2020-06-04)
 [Full Changelog](https://github.com/TheHive-Project/TheHive4py/compare/1.7.0...1.7.1)
 
 **Fixed bugs:**

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ except ImportError:
 
 setup(
     name='thehive4py',
-    version='1.7.1',
+    version='1.7.2',
     description='Python API client for TheHive.',
     long_description=read_md('README.md'),
     author='TheHive-Project',

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ except ImportError:
 
 setup(
     name='thehive4py',
-    version='1.7.2',
+    version='1.8.0',
     description='Python API client for TheHive.',
     long_description=read_md('README.md'),
     author='TheHive-Project',

--- a/thehive4py/api.py
+++ b/thehive4py/api.py
@@ -874,7 +874,7 @@ class TheHiveApi:
         else:
             data = {k: v for k, v in alert.__dict__.items() if k in update_keys}
 
-        if hasattr(data, 'artifacts'):
+        if 'artifacts' in data:
             data['artifacts'] = [a.__dict__ for a in alert.artifacts]
 
         try:

--- a/thehive4py/api.py
+++ b/thehive4py/api.py
@@ -269,7 +269,7 @@ class TheHiveApi:
             task_id (str): Id of the task to delete
 
         Returns:
-            response (requests.Response): Response object including true or false based on the action's success
+            response (requests.Response): Response object including the updated task
 
         Raises:
             CaseException: An error occured during case deletion
@@ -279,8 +279,7 @@ class TheHiveApi:
             return requests.patch(req, headers={'Content-Type': 'application/json'}, json={'status': 'Cancel'},
                                    proxies=self.proxies, auth=self.auth, verify=self.cert)
         except requests.exceptions.RequestException as e:
-            raise CaseException("Case deletion error: {}".format(e))
-
+            raise CaseTaskException("Case task deletion error: {}".format(e))
 
     def create_task_log(self, task_id, case_task_log):
 

--- a/thehive4py/api.py
+++ b/thehive4py/api.py
@@ -882,7 +882,7 @@ class TheHiveApi:
         except requests.exceptions.RequestException as e:
             raise AlertException("Mark alert as unread error: {}".format(e))
 
-    def merge_alert_to_case(self, alert_id, case_id):
+    def merge_alert_into_case(self, alert_id, case_id):
         """
         Merge alert into existing case.
         :param alert_id: The ID of the alert to merge.

--- a/thehive4py/api.py
+++ b/thehive4py/api.py
@@ -56,6 +56,7 @@ class TheHiveApi:
                 }
                 api = TheHiveApi('http://my_thehive:9000',
                     'my_api_key',
+                    None,
                     proxies,
                     True,
                     'my-org'

--- a/thehive4py/api.py
+++ b/thehive4py/api.py
@@ -817,6 +817,7 @@ class TheHiveApi:
             to_exclude.append('externalLink')
 
         data = alert.jsonify(excludes=to_exclude)
+
         try:
             return requests.post(req, headers={'Content-Type': 'application/json'}, data=data, proxies=self.proxies, auth=self.auth, verify=self.cert)
         except requests.exceptions.RequestException as e:
@@ -890,6 +891,7 @@ class TheHiveApi:
 
         if 'artifacts' in data:
             data['artifacts'] = [a.__dict__ for a in alert.artifacts]
+            # data['artifacts'] = [{k: v for k, v in a.__dict__.items()} for a in alert.artifacts]
 
         # Exclude PAP field for TheHive 3
         if self.__isVersion(Version.THEHIVE_3.value):

--- a/thehive4py/api.py
+++ b/thehive4py/api.py
@@ -963,7 +963,7 @@ class TheHiveApi:
 
     def update_case_observables(self, observable, fields=[]):
         """
-        Update a case observable
+        [DEPRECATED] Update a case observable
 
         Arguments:
             observable (CaseObservable): Instance of [CaseObservable][thehive4py.models.CaseObservable] to update. 
@@ -978,19 +978,7 @@ class TheHiveApi:
         Raises:
             CaseObservableException: An error occured during observable update
         """
-        req = self.url + "/api/case/artifact/{}".format(observable.id)
-
-        # Choose which attributes to send
-        update_keys = ['tlp', 'ioc', 'sighted', 'tags', 'message', 'ignoreSimilarity']
-
-        data = {k: v for k, v in observable.__dict__.items() if (
-            len(fields) > 0 and k in fields) or (len(fields) == 0 and k in update_keys)}
-
-        try:
-            return requests.patch(req, headers={'Content-Type': 'application/json'},
-                json=data, proxies=self.proxies, auth=self.auth, verify=self.cert)
-        except requests.exceptions.RequestException as e:
-            raise CaseTaskException("Case observable update error: {}".format(e))
+        return self.update_case_observable(observable.id, observable, fields=fields)
 
     def promote_alert_to_case(self, alert_id, case_template=None):
         """

--- a/thehive4py/api.py
+++ b/thehive4py/api.py
@@ -1025,7 +1025,7 @@ class TheHiveApi:
 
         return self.__find_rows("/api/case/task/_search", **attributes)
 
-    def export_MISP(self, misp_id, case_id):
+    def export_to_misp(self, misp_id, case_id):
         """
         Export selected IOCs of a case as an event to a MISP instance 
         This function triggers the same action triggered when the "Share" button on the TheHive GUI is clicked
@@ -1043,7 +1043,8 @@ class TheHiveApi:
 
         req = self.url + "/api/connector/misp/export/{0}/{1}".format(case_id, misp_id)
         try:
-            return requests.post(req, headers={'Content-Type': 'application/json'}, proxies=self.proxies, auth=self.auth, verify=self.cert)
+            return requests.post(req, headers={'Content-Type': 'application/json'}, proxies=self.proxies,
+                                 json={}, auth=self.auth, verify=self.cert)
         except requests.exceptions.RequestException as e:
             raise TheHiveException("MISP export error: {}".format(e))
         

--- a/thehive4py/api.py
+++ b/thehive4py/api.py
@@ -882,6 +882,20 @@ class TheHiveApi:
         except requests.exceptions.RequestException as e:
             raise AlertException("Mark alert as unread error: {}".format(e))
 
+    def merge_alert_to_case(self, alert_id, case_id):
+        """
+        Merge alert into existing case.
+        :param alert_id: The ID of the alert to merge.
+        :param case_id: The ID of the case where to merge alert
+        :return:
+        """
+        req = self.url + "/api/alert/{}/merge/{}".format(alert_id, case_id)
+
+        try:
+            return requests.post(req, headers={'Content-Type': 'application/json'}, json={}, proxies=self.proxies, auth=self.auth, verify=self.cert)
+        except requests.exceptions.RequestException:
+            raise AlertException("Merge alert to case error: {}".format(e))
+
     def update_alert(self, alert_id, alert, fields=[]):
         """
         Update an alert completely or using specified fields

--- a/thehive4py/api.py
+++ b/thehive4py/api.py
@@ -56,9 +56,9 @@ class TheHiveApi:
                 }
                 api = TheHiveApi('http://my_thehive:9000',
                     'my_api_key',
-                    proxies=proxies,
-                    cert=True,
-                    organisation='my-org'
+                    proxies,
+                    True,
+                    'my-org'
                 )
                 ```
         """

--- a/thehive4py/api.py
+++ b/thehive4py/api.py
@@ -814,6 +814,7 @@ class TheHiveApi:
         # Exclude PAP field for TheHive 3
         if self.__isVersion(Version.THEHIVE_3.value):
             to_exclude.append('pap')
+            to_exclude.append('externalLink')
 
         data = alert.jsonify(excludes=to_exclude)
         try:
@@ -881,12 +882,11 @@ class TheHiveApi:
         req = self.url + "/api/alert/{}".format(alert_id)
 
         # update only the alert attributes that are not read-only
-        update_keys = ['tlp', 'pap', 'severity', 'tags', 'caseTemplate', 'title', 'description', 'customFields']
+        update_keys = ['tlp', 'pap', 'severity', 'tags', 'caseTemplate', 'title', 'description', 'customFields',
+                       'artifacts', 'follow']
 
-        if len(fields) > 0:
-            data = {k: v for k, v in alert.__dict__.items() if k in fields}
-        else:
-            data = {k: v for k, v in alert.__dict__.items() if k in update_keys}
+        data = {k: v for k, v in alert.__dict__.items() if (
+                len(fields) > 0 and k in fields) or (len(fields) == 0 and k in update_keys)}
 
         if 'artifacts' in data:
             data['artifacts'] = [a.__dict__ for a in alert.artifacts]
@@ -894,6 +894,7 @@ class TheHiveApi:
         # Exclude PAP field for TheHive 3
         if self.__isVersion(Version.THEHIVE_3.value):
             data.pop('pap', None)
+            data.pop('externalLink', None)
 
         try:
             return requests.patch(req, headers={'Content-Type': 'application/json'}, json=data, proxies=self.proxies, auth=self.auth, verify=self.cert)

--- a/thehive4py/api.py
+++ b/thehive4py/api.py
@@ -1025,5 +1025,27 @@ class TheHiveApi:
 
         return self.__find_rows("/api/case/task/_search", **attributes)
 
+    def export_MISP(self, misp_id, case_id):
+        """
+        Export selected IOCs of a case as an event to a MISP instance 
+        This function triggers the same action triggered when the "Share" button on the TheHive GUI is clicked
+
+        Arguments:
+            misp_id: identifier of the MISP server
+            case_id (str): Id of the case
+            
+        Returns:
+            response (requests.Response): Response object including a JSON representation of the exported event
+
+        Raises:
+            TheHiveException: An error occured during the export operation
+        """
+
+        req = self.url + "/api/connector/misp/export/{0}/{1}".format(case_id, misp_id)
+        try:
+            return requests.post(req, headers={'Content-Type': 'application/json'}, proxies=self.proxies, auth=self.auth, verify=self.cert)
+        except requests.exceptions.RequestException as e:
+            raise TheHiveException("MISP export error: {}".format(e))
+        
 # - addObservable(file)
 # - addObservable(data)

--- a/thehive4py/api.py
+++ b/thehive4py/api.py
@@ -791,23 +791,47 @@ class TheHiveApi:
         except requests.exceptions.RequestException as e:
             raise CaseTaskException("Case task logs search error: {}".format(e))
 
-    def get_task_logs(self, task_id):
+    def get_task_logs(self, task_id, **attributes):
         """
         Get logs of a case task by its id
 
         Arguments:
             task_id (str): Case task identifier
+            query (dict): A query object, defined in JSON format or using utiliy methods from thehive4py.query module
+            sort (Array): List of fields to sort the result with. Prefix the field name with `-` for descending order
+                and `+` for ascending order
+            range (str): A range describing the number of rows to be returned
 
         Returns:
             response (requests.Response): Response object including a JSON array representing a list of case task logs
 
         Raises:
-            CaseTaskException: An error occured during case task log fetch
+            CaseTaskException: An error occured during case task log search
         """
 
-        req = self.url + "/api/case/task/{}/log".format(task_id)
+        req = self.url + "/api/case/task/log/_search"
+
+        # Add range and sort parameters
+        params = {
+            "range": attributes.get("range", "all"),
+            "sort": attributes.get("sort", [])
+        }
+
+        # Add body
+        parent_criteria = Parent('case_task', Id(task_id))
+
+        # Append the custom query if specified
+        if "query" in attributes:
+            criteria = And(parent_criteria, attributes["query"])
+        else:
+            criteria = parent_criteria
+
+        data = {
+            "query": criteria
+        }
+
         try:
-            return requests.get(req, proxies=self.proxies, auth=self.auth, verify=self.cert)
+            return requests.post(req, params=params, json=data, proxies=self.proxies, auth=self.auth, verify=self.cert)
         except requests.exceptions.RequestException as e:
             raise CaseTaskException("Case task logs search error: {}".format(e))
 

--- a/thehive4py/api.py
+++ b/thehive4py/api.py
@@ -329,6 +329,27 @@ class TheHiveApi:
             except requests.exceptions.RequestException as e:
                 raise CaseObservableException("Case observable create error: {}".format(e))
 
+
+    def delete_case_observable(self, observable_id):
+        """
+        Deletes a TheHive case observable.
+
+        Arguments:
+            observable_id (str): Id of the observable to delete
+
+        Returns:
+            response (requests.Response): Response object including true or false based on the action's success
+
+        Raises:
+            CaseObservableException: An error occured during case observable deletion
+        """
+        req = self.url + "/api/case/artifact/{}".format(observable_id)
+
+        try:
+            return requests.delete(req, proxies=self.proxies, auth=self.auth, verify=self.cert)
+        except requests.exceptions.RequestException as e:
+            raise CaseObservableException("Case observable deletion error: {}".format(e))
+
     def update_case_observable(self, observable_id, case_observable):
 
         """

--- a/thehive4py/api.py
+++ b/thehive4py/api.py
@@ -260,6 +260,27 @@ class TheHiveApi:
         except requests.exceptions.RequestException as e:
             raise CaseTaskException("Case task update error: {}".format(e))
 
+    def delete_case_task(self, task_id):
+        """
+        Deletes a TheHive case task.
+
+        Arguments:
+            task_id (str): Id of the task to delete
+
+        Returns:
+            response (requests.Response): Response object including true or false based on the action's success
+
+        Raises:
+            CaseException: An error occured during case deletion
+        """
+        req = self.url + "/api/case/task/{}".format(task_id)
+        try:
+            return requests.patch(req, headers={'Content-Type': 'application/json'}, json={'status': 'Cancel'},
+                                   proxies=self.proxies, auth=self.auth, verify=self.cert)
+        except requests.exceptions.RequestException as e:
+            raise CaseException("Case deletion error: {}".format(e))
+
+
     def create_task_log(self, task_id, case_task_log):
 
         """

--- a/thehive4py/api.py
+++ b/thehive4py/api.py
@@ -674,7 +674,7 @@ class TheHiveApi:
                 "description": custom_field.description,
                 "type": custom_field.type,
                 "options": custom_field.options,
-                "mandatory": custom_field.madatory
+                "mandatory": custom_field.mandatory
                 }
             }
         req = self.url + "/api/list/custom_fields"

--- a/thehive4py/api.py
+++ b/thehive4py/api.py
@@ -19,7 +19,7 @@ from thehive4py.exceptions import TheHiveException, CaseException, CaseTaskExcep
 
 class TheHiveApi:
 
-    def __init__(self, url: str, principal: str, organisation=None, password=None, proxies={}, cert=True):
+    def __init__(self, url: str, principal: str, password=None, proxies={}, cert=True, organisation=None):
         """
         Python API client for TheHive.
 
@@ -27,7 +27,6 @@ class TheHiveApi:
             url (str): URL of Thehive instance, including the port. Ex: `http://myserver:9000`
             principal (str): The API key, or the username if basic authentication is used.
             password (str): The password for basic authentication or None. Defaults to None
-            organisation (str): The name of the organisation against which api calls will be run. Defaults to None
             proxies (dict): The proxy configuration, would have `http` and `https` attributes. Defaults to {}
                 ```python
                 proxies: {
@@ -36,6 +35,7 @@ class TheHiveApi:
                 }
                 ```
             cert (bool): Wether or not to enable SSL certificate validation
+            organisation (str): The name of the organisation against which api calls will be run. Defaults to None
 
 
         ??? note "Examples"
@@ -56,9 +56,9 @@ class TheHiveApi:
                 }
                 api = TheHiveApi('http://my_thehive:9000',
                     'my_api_key',
-                    organisation='my-org',
                     proxies=proxies,
-                    cert=True
+                    cert=True,
+                    organisation='my-org'
                 )
                 ```
         """
@@ -69,7 +69,7 @@ class TheHiveApi:
         self.organisation = organisation
 
         if self.password is not None:
-            self.auth = BasicAuth(self.principal,self.password, self.organisation)
+            self.auth = BasicAuth(self.principal, self.password, self.organisation)
         else:
             self.auth = BearerAuth(self.principal, self.organisation)
 

--- a/thehive4py/api.py
+++ b/thehive4py/api.py
@@ -483,6 +483,25 @@ class TheHiveApi:
         except requests.exceptions.RequestException as e:
             raise CaseObservableException("Case observables search error: {}".format(e))
 
+    def find_observables(self, **attributes):
+        """
+        Find observables using sort, pagination and a query
+
+        Arguments:
+            query (dict): A query object, defined in JSON format or using utiliy methods from thehive4py.query module
+            sort (Array): List of fields to sort the result with. Prefix the field name with `-` for descending order
+                and `+` for ascending order
+            range (str): A range describing the number of rows to be returned
+
+        Returns:
+            response (requests.Response): Response object including a JSON array of observables.
+
+        Raises:
+            ObservableException: An error occured during observable search
+        """
+
+        return self.__find_rows("/api/case/artifact/_search", **attributes)
+
     def get_case_tasks(self, case_id, **attributes):
         """
         Find tasks of a given case identified by its id

--- a/thehive4py/auth.py
+++ b/thehive4py/auth.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import requests
 from requests.auth import AuthBase
 
 class BasicAuth(AuthBase):

--- a/thehive4py/auth.py
+++ b/thehive4py/auth.py
@@ -4,6 +4,7 @@
 import requests
 from requests.auth import AuthBase
 
+
 class BasicAuth(AuthBase):
     """
     A custom basic authentication class for requests, that takes into account the organisation header

--- a/thehive4py/exceptions.py
+++ b/thehive4py/exceptions.py
@@ -23,6 +23,12 @@ class CaseObservableException(CaseException):
     """
     pass
 
+class ObservableException(TheHiveException):
+    """
+    Exception raised by failure of API calls related to `Observable` handling
+    """
+    pass
+
 class AlertException(TheHiveException):
     """
     Exception raised by failure of API calls related to `Alert` handling

--- a/thehive4py/models.py
+++ b/thehive4py/models.py
@@ -7,11 +7,72 @@ import json
 import os
 import time
 
+from enum import Enum
 import magic
 import requests
 from future.utils import raise_with_traceback
 
 from thehive4py.exceptions import TheHiveException, CaseException
+
+
+class Tlp(Enum):
+    """
+    Enumeration representing TLP, used in cases, observables and alerts
+
+    Possible values: WHITE, GREEN, AMBER, RED
+    """
+    WHITE = 0
+    GREEN = 1
+    AMBER = 2
+    RED = 3
+
+
+class Pap(Enum):
+    """
+    Enumeration representing PAP, used in cases, observables and alerts (TheHive 4 only)
+
+    Possible values: WHITE, GREEN, AMBER, RED
+    """
+    WHITE = 0
+    GREEN = 1
+    AMBER = 2
+    RED = 3
+
+
+class Severity(Enum):
+    """
+    Enumeration representing severity, used in cases and alerts
+
+    Possible values: LOW, MEDIUM, HIGH, CRITICAL
+    """
+    LOW = 1
+    MEDIUM = 2
+    HIGH = 3
+    CRITICAL = 4
+
+
+class CaseStatus(Enum):
+    """
+    Enumeration representing case statuses
+
+    Possible values: OPEN, RESOLVED, DELETED, DUPLICATE
+    """
+    OPEN = 'Open'
+    RESOLVED = 'Resolved'
+    DELETED = 'Deleted'
+    DUPLICATE = 'Duplicate'
+
+
+class TaskStatus(Enum):
+    """
+    Enumeration representing task statuses
+
+    Possible values: WAITING, INPROGRESS, COMPLETED, CANCEL
+    """
+    WAITING = 'Waiting'
+    INPROGRESS = 'InProgress'
+    COMPLETED = 'Completed',
+    CANCEL = 'Cancel'
 
 
 class CustomJsonEncoder(json.JSONEncoder):
@@ -220,9 +281,9 @@ class Case(JSONSerializable):
             'id': None,
             'title': None,
             'description': None,
-            'tlp': 2,
-            'pap': 2,
-            'severity': 2,
+            'tlp': Tlp.AMBER.value,
+            'pap': Pap.AMBER.value,
+            'severity': Severity.MEDIUM.value,
             'flag': False,
             'tags': [],
             'startDate': int(time.time()) * 1000,
@@ -375,7 +436,7 @@ class CaseTask(JSONSerializable):
 
         self.id = attributes.get('id', None)
         self.title = attributes.get('title', None)
-        self.status = attributes.get('status', 'Waiting')
+        self.status = attributes.get('status', TaskStatus.WAITING.value)
         self.flag = attributes.get('flag', False)
         self.description = attributes.get('description', None)
         self.owner = attributes.get('owner', None)
@@ -433,10 +494,10 @@ class CaseTemplate(JSONSerializable):
         self.id = attributes.get('id', None)
         self.titlePrefix = attributes.get('titlePrefix', None)
         self.description = attributes.get('description', None)
-        self.severity = attributes.get('severity', 2)
+        self.severity = attributes.get('severity', Severity.MEDIUM.value)
         self.flag = attributes.get('flag', False)
-        self.tlp = attributes.get('tlp', 2)
-        self.pap = attributes.get('pap', 2)
+        self.tlp = attributes.get('tlp', Tlp.AMBER.value)
+        self.pap = attributes.get('pap', Pap.AMBER.value)
         self.tags = attributes.get('tags', [])
         self.metrics = attributes.get('metrics', {})
         self.customFields = attributes.get('customFields', {})
@@ -480,7 +541,7 @@ class CaseObservable(JSONSerializable):
         self.id = attributes.get('id', None)
         self.dataType = attributes.get('dataType', None)
         self.message = attributes.get('message', None)
-        self.tlp = attributes.get('tlp', 2)
+        self.tlp = attributes.get('tlp', Tlp.AMBER.value)
         self.tags = attributes.get('tags', [])
         self.ioc = attributes.get('ioc', False)
         self.sighted = attributes.get('sighted', False)
@@ -520,8 +581,8 @@ class Alert(JSONSerializable):
             attributes = attributes['json']
 
         self.id = attributes.get('id', None)
-        self.tlp = attributes.get('tlp', 2)
-        self.severity = attributes.get('severity', 2)
+        self.tlp = attributes.get('tlp', Tlp.AMBER.value)
+        self.severity = attributes.get('severity', Severity.MEDIUM.value)
         self.date = attributes.get('date', int(time.time()) * 1000)
         self.tags = attributes.get('tags', [])
         self.caseTemplate = attributes.get('caseTemplate', None)
@@ -566,7 +627,7 @@ class AlertArtifact(JSONSerializable):
 
         self.dataType = attributes.get('dataType', None)
         self.message = attributes.get('message', None)
-        self.tlp = attributes.get('tlp', 2)
+        self.tlp = attributes.get('tlp', Tlp.AMBER.value)
         self.tags = attributes.get('tags', [])
         self.ioc = attributes.get('ioc', False)
         self.sighted = attributes.get('sighted', False)

--- a/thehive4py/models.py
+++ b/thehive4py/models.py
@@ -459,6 +459,7 @@ class CaseObservable(JSONSerializable):
         dataType (str): Observable's type, must be a valid type, one of the defined data types in TheHive. Default: None
         message (str): Observable's description. Default: None
         tlp (Enum): Case's TLP: `0`, `1`, `2`, `3` for `WHITE`, `GREEN`, `AMBER`, `RED`. Default: `2`
+        pap (Enum): Case's PAP: `0`, `1`, `2`, `3` for `WHITE`, `GREEN`, `AMBER`, `RED`. Default: `2`
         ioc (bool): Observable's ioc flag, `True` to mark an observable as IOC. Default: `False`
         sighted (bool): Observable's sighted flag, `True` to mark the observable as sighted. Default: `False`
         tags (str[]): List of observable tags. Default: `[]`

--- a/thehive4py/models.py
+++ b/thehive4py/models.py
@@ -533,6 +533,7 @@ class CaseObservable(JSONSerializable):
         pap (Enum): Case's PAP: `0`, `1`, `2`, `3` for `WHITE`, `GREEN`, `AMBER`, `RED`. Default: `2`
         ioc (bool): Observable's ioc flag, `True` to mark an observable as IOC. Default: `False`
         sighted (bool): Observable's sighted flag, `True` to mark the observable as sighted. Default: `False`
+        ignoreSimilarity (bool): Observable's similarity ignore flag. `True`to ignore the observable during similarity computing
         tags (str[]): List of observable tags. Default: `[]`
         data (str): Observable's data:
 
@@ -542,6 +543,9 @@ class CaseObservable(JSONSerializable):
 
     !!! Warning
         At least, one of `tags` or `message` are required. You cannot create an observable without specifying one of those fields
+
+    !!! Warning
+        `ignoreSimilarity` attribute is available in TheHive 4 ONLY
     """
 
     def __init__(self, **attributes):
@@ -555,6 +559,7 @@ class CaseObservable(JSONSerializable):
         self.tags = attributes.get('tags', [])
         self.ioc = attributes.get('ioc', False)
         self.sighted = attributes.get('sighted', False)
+        self.ignoreSimilarity = attributes.get('ignoreSimilarity', False)
 
         data = attributes.get('data', [])
         if self.dataType == 'file':
@@ -630,12 +635,16 @@ class AlertArtifact(JSONSerializable):
         tlp (Enum): Case's TLP: `0`, `1`, `2`, `3` for `WHITE`, `GREEN`, `AMBER`, `RED`. Default: `2`
         ioc (bool): Observable's ioc flag, `True` to mark an observable as IOC. Default: `False`
         sighted (bool): Observable's sighted flag, `True` to mark the observable as sighted. Default: `False`
+        ignoreSimilarity (bool): Observable's similarity ignore flag. `True`to ignore the observable during similarity computing
         tags (str[]): List of observable tags. Default: `[]`
         data (str): Observable's data:
 
             - If the `dataType` field is set to `file`, the `data` field should contain a file path to be used as attachment
             - Otherwise, the `data` value is the observable's value
         json (JSON): If the field is not equal to None, the observable is instantiated using the JSON value instead of the arguements
+
+        !!! Warning
+            `ignoreSimilarity` attribute is available in TheHive 4 ONLY
     """
 
     def __init__(self, **attributes):
@@ -648,6 +657,9 @@ class AlertArtifact(JSONSerializable):
         self.tags = attributes.get('tags', [])
         self.ioc = attributes.get('ioc', False)
         self.sighted = attributes.get('sighted', False)
+
+        if 'ignoreSimilarity' in attributes:
+            self.ignoreSimilarity = attributes.get('ignoreSimilarity', False)
 
         if self.dataType == 'file':
             if 'attachment' in attributes:

--- a/thehive4py/models.py
+++ b/thehive4py/models.py
@@ -15,6 +15,16 @@ from future.utils import raise_with_traceback
 from thehive4py.exceptions import TheHiveException, CaseException
 
 
+class Version(Enum):
+    """
+    Enumeration representing a version used to specify the version of TheHive instance
+
+    Possible values: THEHIVE_3, THEHIVE_4
+    """
+    THEHIVE_3 = 3
+    THEHIVE_4 = 4
+
+
 class Tlp(Enum):
     """
     Enumeration representing TLP, used in cases, observables and alerts
@@ -560,6 +570,7 @@ class Alert(JSONSerializable):
     Arguments:
         id (str): Alert's id. Default: None
         tlp (Enum): Alert's TLP: `0`, `1`, `2`, `3` for `WHITE`, `GREEN`, `AMBER`, `RED`. Default: `2`
+        pap (Enum): Alert's PAP: `0`, `1`, `2`, `3` for `WHITE`, `GREEN`, `AMBER`, `RED`. Default: `2` (TheHive 4 ONLY)
         severity (Enum): Alert's severity: `1`, `2`, `3`, `4` for `LOW`, `MEDIUM`, `HIGH`, `CRTICAL`. Default: `2`
         date (datetime): Alert's occur date. Default: `Now()`
         tags (str[]): List of alert tags. Default: `[]`
@@ -574,6 +585,9 @@ class Alert(JSONSerializable):
         caseTemplate (str): Alert template's name. Default: `None`
 
         json (JSON): If the field is not equal to None, the Alert is instantiated using the JSON value instead of the arguements
+
+    !!! Warning
+            `pap` attribute is available in TheHive 4 ONLY
     """
 
     def __init__(self, **attributes):
@@ -582,6 +596,7 @@ class Alert(JSONSerializable):
 
         self.id = attributes.get('id', None)
         self.tlp = attributes.get('tlp', Tlp.AMBER.value)
+        self.pap = attributes.get('pap', Pap.AMBER.value)
         self.severity = attributes.get('severity', Severity.MEDIUM.value)
         self.date = attributes.get('date', int(time.time()) * 1000)
         self.tags = attributes.get('tags', [])

--- a/thehive4py/models.py
+++ b/thehive4py/models.py
@@ -579,6 +579,7 @@ class Alert(JSONSerializable):
         type (str): Alert's type. Default: None
         source (str): Alert's source. Default: None
         sourceRef (str): Alert's source reference. Used to specify the unique identifier of the alert. Default: None
+        externalLink (str): Alert's external link. Used to easily navigate to the source of the alert. Default: None
         description (str): Alert's description. Default: None
         customFields (CustomField[]): A set of CustomField instances, or the result of a CustomFieldHelper.build() method. Default: `{}`
 
@@ -601,6 +602,7 @@ class Alert(JSONSerializable):
         self.date = attributes.get('date', int(time.time()) * 1000)
         self.tags = attributes.get('tags', [])
         self.caseTemplate = attributes.get('caseTemplate', None)
+        self.externalLink = attributes.get('externalLink', None)
 
         self.title = self.attr(attributes, 'title', None, 'Missing alert title')
         self.type = self.attr(attributes, 'type', None, 'Missing alert type')

--- a/thehive4py/models.py
+++ b/thehive4py/models.py
@@ -588,7 +588,7 @@ class Alert(JSONSerializable):
         json (JSON): If the field is not equal to None, the Alert is instantiated using the JSON value instead of the arguements
 
     !!! Warning
-            `pap` attribute is available in TheHive 4 ONLY
+            `pap`, `externalLink` attributes are available in TheHive 4 ONLY
     """
 
     def __init__(self, **attributes):


### PR DESCRIPTION
 Make get_task_logs() use 'api/case/task/log/_search/' API endpoint. This allows specifying params and also query. Current implementation of this method only returns 10 case task logs at max. I believe this addresses issue #160 