### PR TITLE
Get alert with similarities

### DIFF
--- a/thehive4py/api.py
+++ b/thehive4py/api.py
@@ -840,12 +840,13 @@ class TheHiveApi:
         except requests.exceptions.RequestException as e:
             raise AlertException("Alert update error: {}".format(e))
 
-    def get_alert(self, alert_id):
+    def get_alert(self, alert_id, get_similar_cases = False):
         """
         Get an alert by its id
 
         Arguments:
             alert_id (str): Id of the alert
+            get_similar_cases (book): True if similar cases should be retrieved (Default False)
 
         Returns:
             response (requests.Response): Response object including a JSON representation of the alert
@@ -854,6 +855,8 @@ class TheHiveApi:
             AlertException: An error occured during alert update
         """
         req = self.url + "/api/alert/{}".format(alert_id)
+        if get_similar_cases:
+            req = req + "?similarity=1"
 
         try:
             return requests.get(req, proxies=self.proxies, auth=self.auth, verify=self.cert)

--- a/thehive4py/api.py
+++ b/thehive4py/api.py
@@ -846,7 +846,7 @@ class TheHiveApi:
 
         Arguments:
             alert_id (str): Id of the alert
-            get_similar_cases (book): True if similar cases should be retrieved (Default False)
+            get_similar_cases (bool): True if similar cases should be retrieved (Default False)
 
         Returns:
             response (requests.Response): Response object including a JSON representation of the alert

--- a/thehive4py/api.py
+++ b/thehive4py/api.py
@@ -483,6 +483,25 @@ class TheHiveApi:
         except requests.exceptions.RequestException as e:
             raise CaseObservableException("Case observables search error: {}".format(e))
 
+    def find_observables(self, **attributes):
+        """
+        Find observables using sort, pagination and a query
+
+        Arguments:
+            query (dict): A query object, defined in JSON format or using utiliy methods from thehive4py.query module
+            sort (Array): List of fields to sort the result with. Prefix the field name with `-` for descending order
+                and `+` for ascending order
+            range (str): A range describing the number of rows to be returned
+
+        Returns:
+            response (requests.Response): Response object including a JSON array of observables.
+
+        Raises:
+            ObservableException: An error occured during observable search
+        """
+
+        return self.__find_rows("/api/case/artifact/_search", **attributes)
+
     def get_case_tasks(self, case_id, **attributes):
         """
         Find tasks of a given case identified by its id

--- a/thehive4py/exceptions.py
+++ b/thehive4py/exceptions.py
@@ -23,6 +23,12 @@ class CaseObservableException(CaseException):
     """
     pass
 
+class ObservableException(TheHiveException):
+    """
+    Exception raised by failure of API calls related to `Observable` handling
+    """
+    pass
+
 class AlertException(TheHiveException):
     """
     Exception raised by failure of API calls related to `Alert` handling


### PR DESCRIPTION
Added a boolean flag to get similar cases within the alert.

Previous API request was:

/api/alert/ffd8a6ff0cc6a65a34afc86306f297d0

With get_similar_case = True is:

/api/alert/ffd8a6ff0cc6a65a34afc86306f297d0?similarity=1

The PR is backward compatible (get_similar_case = False by default).
