### PR TITLE
Fixed missing status attribute in CaseObservable

### DIFF
--- a/thehive4py/models.py
+++ b/thehive4py/models.py
@@ -462,6 +462,7 @@ class CaseObservable(JSONSerializable):
         ioc (bool): Observable's ioc flag, `True` to mark an observable as IOC. Default: `False`
         sighted (bool): Observable's sighted flag, `True` to mark the observable as sighted. Default: `False`
         tags (str[]): List of observable tags. Default: `[]`
+        status (str): Observable's status (Ok or Deleted). Default 'Ok'
         data (str): Observable's data:
 
             - If the `dataType` field is set to `file`, the `data` field should contain a file path to be used as attachment
@@ -483,6 +484,7 @@ class CaseObservable(JSONSerializable):
         self.tags = attributes.get('tags', [])
         self.ioc = attributes.get('ioc', False)
         self.sighted = attributes.get('sighted', False)
+        self.status = attributes.get('status', 'Ok')
 
         data = attributes.get('data', [])
         if self.dataType == 'file':


### PR DESCRIPTION
Added line `self.status = attributes.get('status', 'Ok')` so that the model of CaseObservable includes the missing status attributes indicating if an observable has been deleted or not.

By default, it's set to Ok (not deleted).

Also adjusted the docstring above.

Tested by myself with some thehive4py scripts and responders that were able to differentiate deleted and existing observables. 

First PR, new to Pythonand to The Hive, sorry if I did some mistake or corrupted the code (hopefully not)