### PR TITLE
Issue #173: corrected typo 'custom_field.madatory' to 'custom_field.mandatory'

### DIFF
--- a/thehive4py/api.py
+++ b/thehive4py/api.py
@@ -674,7 +674,7 @@ class TheHiveApi:
                 "description": custom_field.description,
                 "type": custom_field.type,
                 "options": custom_field.options,
-                "mandatory": custom_field.madatory
+                "mandatory": custom_field.mandatory
                 }
             }
         req = self.url + "/api/list/custom_fields"


### PR DESCRIPTION
Fix for error identified by user CanTopay in issue #173. I corrected the  typo 'custom_field.madatory' to 'custom_field.mandatory'.