### PR TITLE
Use dict key lookup instead of hasattr

### DIFF
--- a/thehive4py/api.py
+++ b/thehive4py/api.py
@@ -853,7 +853,7 @@ class TheHiveApi:
         else:
             data = {k: v for k, v in alert.__dict__.items() if k in update_keys}
 
-        if hasattr(data, 'artifacts'):
+        if 'artifacts' in data:
             data['artifacts'] = [a.__dict__ for a in alert.artifacts]
 
         try:


### PR DESCRIPTION
PR related to #195 

An alert's artifacts cannot be updated using the `update_alert` method because artifact serialization is skipped due to the incorrect usage of `hasattr` on the `data` patch dictionary.
Using the `in` operator instead to look up the key in the dictionary and trigger the artifact serialization if needed.