### PR TITLE
Fix exception handling for merge_alert_into_case

### DIFF
--- a/thehive4py/api.py
+++ b/thehive4py/api.py
@@ -893,7 +893,7 @@ class TheHiveApi:
 
         try:
             return requests.post(req, headers={'Content-Type': 'application/json'}, json={}, proxies=self.proxies, auth=self.auth, verify=self.cert)
-        except requests.exceptions.RequestException:
+        except requests.exceptions.RequestException as e:
             raise AlertException("Merge alert to case error: {}".format(e))
 
     def update_alert(self, alert_id, alert, fields=[]):


### PR DESCRIPTION
Linters can be a good thing.

Fix exception handling error introduced in https://github.com/TheHive-Project/TheHive4py/pull/164