### PR TITLE
[Feature] Add the possibility to have a client certificate

### DIFF
--- a/thehive4py/api.py
+++ b/thehive4py/api.py
@@ -4,11 +4,9 @@
 import json
 import sys
 
-import magic
 import os
 import warnings
 import json
-import magic
 import requests
 
 from thehive4py.auth import BasicAuth, BearerAuth


### PR DESCRIPTION
Hi,

As explained here : https://github.com/TheHive-Project/TheHiveDocs/blob/master/admin/certauth.md, we can use a proxy to support HTTPS for TheHive.
However, we can also use a client certificate with the TheHive4py API to authenticate to a TheHive instance behind a proxy.
This PR adds the possibility to do this using the requests library.

This is linked to a request for the TheHive/Cortex Splunk app : https://github.com/LetMeR00t/TA-thehive-cortex/issues/15


**BE AWARE : "cert" was renamed as "verify" as "cert" is used as the client certificate by the requests lib**