### PR TITLE
JSON decode error fix

### DIFF
--- a/thehive4py/session.py
+++ b/thehive4py/session.py
@@ -1,6 +1,6 @@
 import json as jsonlib
 from collections import UserDict
-from json.decoder import JSONDecodeError
+from requests import JSONDecodeError
 from os import PathLike
 from typing import Any, Optional, Union
 

--- a/thehive4py/session.py
+++ b/thehive4py/session.py
@@ -1,6 +1,6 @@
 import json as jsonlib
 from collections import UserDict
-from requests import JSONDecodeError
+from json.decoder import JSONDecodeError
 from os import PathLike
 from typing import Any, Optional, Union
 


### PR DESCRIPTION
Outlined in #255 there can be JSON decode errors when running TheHive4Py on AWS Lambda most likely due to Lambda not including the correct package that contains JSONDecodeError.

This PR updates the JSONDecodeError to come from the requests package. Thank you to all the hard work from @octocolby for identifying the root cause of this issue and providing a fix.