### PR TITLE
Persist error response data in TheHiveError

### DIFF
--- a/thehive4py/errors.py
+++ b/thehive4py/errors.py
@@ -1,2 +1,14 @@
+from typing import Optional
+
+from requests import Response
+
+
 class TheHiveError(Exception):
     """Base error class for TheHive API."""
+
+    def __init__(
+        self, message: str, response: Optional[Response] = None, *args, **kwargs
+    ):
+        super().__init__(message, *args, **kwargs)
+        self.message = message
+        self.response = response

--- a/thehive4py/session.py
+++ b/thehive4py/session.py
@@ -126,4 +126,4 @@ class TheHiveSession(requests.Session):
             error_text = response.text
         else:
             error_text = f"{json_data['type']} - {json_data['message']}"
-        raise TheHiveError(error_text)
+        raise TheHiveError(message=error_text, response=response)


### PR DESCRIPTION
This one is a convenience feature to better handle exceptions due to API errors.

At the moment one only has access to the parsed error message of an exception, e.g.:

```python
try:
    ...
except TheHiveError as err:
    if "CreateError" in str(err):
        print("handle create errors here")
    else:
        print("do generic error handling here")
```

From the above it is clear that the handling capabilities are limited to the parsed error string, while with this change one can do:

```python
try:
    ...
except TheHiveError as err:
    if "CreateError" in err.message:
        print("handle create errors here")
    else:
        if err.response:
            if err.response.status_code == 401:
                print("handle authentication error here")
            else:
                # do anything generic with the error response here
                error_json = err.response.json()
```
        