### PR TITLE
Download an attachment from an observable

### DIFF
--- a/thehive4py/endpoints/observable.py
+++ b/thehive4py/endpoints/observable.py
@@ -111,3 +111,13 @@ class ObservableEndpoint(EndpointBase):
             params={"name": "observable.count"},
             json={"query": query},
         )
+
+    def download_attachment(
+        self, observable_id: str, attachment_id: str, attachment_path: str, as_zip: bool = False
+    ) -> None:
+        return self._session.make_request(
+            "GET",
+            path=f"/api/v1/observable/{observable_id}/attachment/{attachment_id}/download",
+            params={"asZip": as_zip},
+            download_path=attachment_path,
+        )

--- a/thehive4py/endpoints/observable.py
+++ b/thehive4py/endpoints/observable.py
@@ -113,11 +113,11 @@ class ObservableEndpoint(EndpointBase):
         )
 
     def download_attachment(
-        self, observable_id: str, attachment_id: str, attachment_path: str, as_zip: bool = False
+        self, observable_id: str, attachment_id: str, observable_path: str, as_zip: bool = False
     ) -> None:
         return self._session.make_request(
             "GET",
             path=f"/api/v1/observable/{observable_id}/attachment/{attachment_id}/download",
             params={"asZip": as_zip},
-            download_path=attachment_path,
+            download_path=observable_path,
         )

--- a/thehive4py/endpoints/observable.py
+++ b/thehive4py/endpoints/observable.py
@@ -113,15 +113,15 @@ class ObservableEndpoint(EndpointBase):
         )
 
     def download_attachment(
-        self, 
-        observable_id: str, 
-        attachment_id: str, 
-        observable_path: str, 
+        self,
+        observable_id: str,
+        attachment_id: str,
+        observable_path: str,
         as_zip: bool = False
     ) -> None:
         return self._session.make_request(
             "GET",
-            path=(f"/api/v1/observable/{observable_id}
+            path=(f"/api/v1/observable/{observable_id}"
                   f"/attachment/{attachment_id}/download"),
             params={"asZip": as_zip},
             download_path=observable_path,

--- a/thehive4py/endpoints/observable.py
+++ b/thehive4py/endpoints/observable.py
@@ -113,11 +113,16 @@ class ObservableEndpoint(EndpointBase):
         )
 
     def download_attachment(
-        self, observable_id: str, attachment_id: str, observable_path: str, as_zip: bool = False
+        self, 
+        observable_id: str, 
+        attachment_id: str, 
+        observable_path: str, 
+        as_zip: bool = False
     ) -> None:
         return self._session.make_request(
             "GET",
-            path=f"/api/v1/observable/{observable_id}/attachment/{attachment_id}/download",
+            path=(f"/api/v1/observable/{observable_id}
+                  f"/attachment/{attachment_id}/download"),
             params={"asZip": as_zip},
             download_path=observable_path,
         )


### PR DESCRIPTION
Add a method to download an attachment from the observableendpoint class and be able to retrieve a file from an observable's id. The download can also be done with a zip and the parameter as_zip.