### PR TITLE
add py.typed to the project to please mypy and make the library PEP-561 compliant

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,3 +33,6 @@ dev = ["thehive4py[audit, lint, test, build]"]
 
 [tool.setuptools.packages.find]
 include = ["thehive4py*"]
+
+[tool.setuptools.package-data]
+thehive4py = ["py.typed"]


### PR DESCRIPTION
Recently in other projects that are using `thehive4py` v2.x I started to receive errors from `mypy` like `error: Skipping analyzing 'thehive4py.xxx': found module but no type hints or library stubs`

Weird that it didn't show up before in CI checks.

Anyways it is an easy fix as according to PEP-561 a placeholder file called `py.typed` in the project root should fix the issue, and then `mypy` would respect the typehints of the library.