### PR TITLE
mandatory task typing

### DIFF
--- a/thehive4py/types/task.py
+++ b/thehive4py/types/task.py
@@ -15,6 +15,7 @@ class InputTask(InputTaskRequired, total=False):
     order: int
     dueDate: int
     assignee: str
+    mandatory: bool
 
 
 class OutputTaskRequired(TypedDict):


### PR DESCRIPTION
In TheHive5 there is an option to create mandatory tasks in cases. These tasks block the closure of the case until they are completed. For this you just have to add True (as a boolean) in the 'mandatory' key of the json.