### PR TITLE
Align pyproject.toml to Git Repo License of MIT

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.8"
 dependencies = ["requests>=2.27"]
 readme = "README.md"
 keywords = ["thehive5", "api", "client"]
-license = { text = "AGPL-V3" }
+license = { text = "MIT" }
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "License :: OSI Approved :: GNU Affero General Public License v3",
+    "License :: OSI Approved :: MIT License",
 ]
 authors = [{ name = "Szabolcs Antal", email = "antalszabolcs01@gmail.com" }]
 


### PR DESCRIPTION
The license in the Git repo for TheHive4py moved from AGPLv3+ to MIT, but the toml code did not get updated, this catches up the rest of the build environment and should allow for proper license use

At this moment, we cannot create a form of Docker Container because the build process does not support the use of the AGPLv3+ license and we were wondering why as the current version of TheHive4py is MIT licensed

These changes should allow a new release to be used in our and other license verified build processes