### PR TITLE
Fix deprecations, add warning for Contains

### DIFF
--- a/tests/test_query_filters.py
+++ b/tests/test_query_filters.py
@@ -1,4 +1,5 @@
 import pytest
+
 from thehive4py import TheHiveApi
 from thehive4py.helpers import now_to_ts
 from thehive4py.query.filters import (
@@ -22,7 +23,7 @@ from thehive4py.types.user import OutputUser
 
 
 class TestQueryFilters:
-    def test_between_contains_in(self, thehive: TheHiveApi, test_user: OutputUser):
+    def test_between_contains_has_in(self, thehive: TheHiveApi, test_user: OutputUser):
         assert thehive.user.find(
             filters=Between(field="_createdAt", start=0, end=now_to_ts())
         )

--- a/tests/test_query_filters.py
+++ b/tests/test_query_filters.py
@@ -1,3 +1,4 @@
+import pytest
 from thehive4py import TheHiveApi
 from thehive4py.helpers import now_to_ts
 from thehive4py.query.filters import (
@@ -7,6 +8,7 @@ from thehive4py.query.filters import (
     Eq,
     Gt,
     Gte,
+    Has,
     Id,
     In,
     Like,
@@ -24,7 +26,9 @@ class TestQueryFilters:
         assert thehive.user.find(
             filters=Between(field="_createdAt", start=0, end=now_to_ts())
         )
-        assert thehive.user.find(filters=Contains(field="login"))
+        with pytest.deprecated_call():
+            assert thehive.user.find(filters=Contains(field="login"))
+        assert thehive.user.find(filters=Has(field="login"))
         assert thehive.user.find(
             filters=In(field="login", values=["...", "xyz", test_user["login"]])
         )

--- a/thehive4py/query/__init__.py
+++ b/thehive4py/query/__init__.py
@@ -2,7 +2,7 @@ from typing import List, Union
 
 from .filters import Between, Contains, EndsWith, Eq
 from .filters import FilterExpr as _FilterExpr
-from .filters import Gt, Gte, Id, In, Like, Lt, Lte, Match, Ne, StartsWith
+from .filters import Gt, Gte, Has, Id, In, Like, Lt, Lte, Match, Ne, StartsWith
 from .page import Paginate
 from .sort import Asc, Desc
 from .sort import SortExpr as _SortExpr

--- a/thehive4py/query/filters.py
+++ b/thehive4py/query/filters.py
@@ -1,6 +1,7 @@
 from collections import UserDict as _UserDict
 from typing import Any as _Any
 from typing import Union as _Union
+import warnings
 
 FilterExpr = _Union["_FilterBase", dict]
 
@@ -34,28 +35,28 @@ class Lt(_FilterBase):
     """Field less than value."""
 
     def __init__(self, field: str, value: _Any):
-        super().__init__(_lt={field: value})
+        super().__init__(_lt={"_field": field, "_value": value})
 
 
 class Gt(_FilterBase):
     """Field greater than value."""
 
     def __init__(self, field: str, value: _Any):
-        super().__init__(_gt={field: value})
+        super().__init__(_gt={"_field": field, "_value": value})
 
 
 class Lte(_FilterBase):
     """Field less than or equal value."""
 
     def __init__(self, field: str, value: _Any):
-        super().__init__(_lte={field: value})
+        super().__init__(_lte={"_field": field, "_value": value})
 
 
 class Gte(_FilterBase):
     """Field less than or equal value."""
 
     def __init__(self, field: str, value: _Any):
-        super().__init__(_gte={field: value})
+        super().__init__(_gte={"_field": field, "_value": value})
 
 
 class Ne(_FilterBase):
@@ -111,7 +112,21 @@ class Contains(_FilterBase):
     """Object contains the field."""
 
     def __init__(self, field: str):
+        warnings.warn(
+            message="The `Contains` filter has been deprecated. "
+            "Please use the `Has` filter to prevent breaking "
+            "changes in the future.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__(_contains=field)
+
+
+class Has(_FilterBase):
+    """Object contains the field."""
+
+    def __init__(self, field: str):
+        super().__init__(_has=field)
 
 
 class Like(_FilterBase):


### PR DESCRIPTION
This PR fixes the deprecation warnings of the comparison operators.

Unsure as if with `Contains` we should also update the dict field, not just emit a warning.