### PR TITLE
Fix InputAnalyzerJob type and add regression test

### DIFF
--- a/tests/test_cortex_endpoint.py
+++ b/tests/test_cortex_endpoint.py
@@ -1,8 +1,21 @@
 from thehive4py.client import TheHiveApi
 from thehive4py.types.case import OutputCase
+from thehive4py.types.observable import OutputObservable
 
 
 class TestCortexEndpoint:
+    def test_create_analyzer_job(
+        self, thehive: TheHiveApi, test_observable: OutputObservable
+    ):
+        output_analyzer_job = thehive.cortex.create_analyzer_job(
+            job={
+                "analyzerId": "example",
+                "cortexId": "cortex",
+                "artifactId": test_observable["_id"],
+            }
+        )
+        assert output_analyzer_job["_type"] == "case_artifact_job"
+
     def test_list_analyzers(self, thehive: TheHiveApi):
         analyzers = thehive.cortex.list_analyzers()
         assert analyzers == []

--- a/thehive4py/types/cortex.py
+++ b/thehive4py/types/cortex.py
@@ -86,7 +86,7 @@ class InputResponderAction(InputResponderActionRequired, total=False):
 class InputAnalyzerJobRequired(TypedDict):
     analyzerId: str
     cortexId: str
-    observableId: str
+    artifactId: str
 
 
 class InputAnalyzerJob(InputAnalyzerJobRequired, total=False):


### PR DESCRIPTION
As per https://github.com/TheHive-Project/TheHive4py/issues/395, this PR swaps the observableId field with the articfactId field and adds a regression test.