### PR TITLE
#398 - Remove `update_share` method from case endpoint

### DIFF
--- a/tests/test_case_endpoint.py
+++ b/tests/test_case_endpoint.py
@@ -267,19 +267,6 @@ class TestCaseEndpoint:
         thehive.case.remove_share(share_id=shares[0]["_id"])
         assert len(thehive.case.list_shares(case_id=test_case["_id"])) == 0
 
-    @pytest.mark.skip(reason="patch endpoint errors out")
-    def test_update_share(self, thehive: TheHiveApi, test_case: OutputCase):
-        organisation = "share-org"
-        share: InputShare = {"organisation": organisation, "profile": "read-only"}
-
-        created_share = thehive.case.share(case_id=test_case["_id"], shares=[share])[0]
-
-        update_profile = "read-only"
-        thehive.case.update_share(share_id=created_share["_id"], profile=update_profile)
-
-        updated_share = thehive.case.share(case_id=test_case["_id"], shares=[share])[0]
-        assert updated_share["profileName"] == update_profile
-
     @pytest.mark.skip(reason="integrator container only supports a single org ")
     def test_share_and_set_share(self, thehive: TheHiveApi, test_case: OutputCase):
         organisation = "share-org"

--- a/thehive4py/endpoints/case.py
+++ b/thehive4py/endpoints/case.py
@@ -367,11 +367,6 @@ class CaseEndpoint(EndpointBase):
             "DELETE", path=f"/api/v1/case/share/{share_id}"
         )
 
-    def update_share(self, share_id: str, profile: str) -> None:
-        return self._session.make_request(
-            "PATCH", path=f"/api/v1/case/share/{share_id}", json={"profile": profile}
-        )
-
     def find(
         self,
         filters: Optional[FilterExpr] = None,


### PR DESCRIPTION
As per #398 