### PR TITLE
#428 - Update OutputObservableRequired type

### DIFF
--- a/thehive4py/types/observable.py
+++ b/thehive4py/types/observable.py
@@ -31,7 +31,9 @@ class OutputObservableRequired(TypedDict):
     dataType: str
     startDate: int
     tlp: int
+    tlpLabel: str
     pap: int
+    papLabel: str
     ioc: bool
     sighted: bool
     reports: dict


### PR DESCRIPTION
Update OutputObservableRequired type with the tlpLabel and papLabel as both attributes are stated as required here https://docs.strangebee.com/thehive/api-docs/#tag/Observable/operation/Get%20Observable.