### PR TITLE
#480 - Fix deploy_docs flag typo

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -97,7 +97,7 @@ def deploy_docs(session: nox.Session):
         "latest",
         "--update-aliases",
         "--push",
-        " --allow-empty",
+        "--allow-empty",
     )
 
 


### PR DESCRIPTION
Fix an empty whitespace typo in the `--allow-empty` flag (how ironic...)