### PR TITLE
#532 - Fix misaligned return type in case.find_pages

### DIFF
--- a/thehive4py/endpoints/case.py
+++ b/thehive4py/endpoints/case.py
@@ -746,7 +746,7 @@ class CaseEndpoint(EndpointBase):
         filters: Optional[FilterExpr] = None,
         sortby: Optional[SortExpr] = None,
         paginate: Optional[Paginate] = None,
-    ) -> List[OutputProcedure]:
+    ) -> List[OutputCasePage]:
         """Find pages related to a case.
 
         Args:


### PR DESCRIPTION
As per #532 